### PR TITLE
On crashes, it now tries to reset all the pins to LOW and throws a DebugBreak

### DIFF
--- a/source/arduino.h
+++ b/source/arduino.h
@@ -552,6 +552,21 @@ inline int RunArduinoSketch()
         ret = 1;
         Log("\nSketch Aborted! A fatal error has occurred:\n");
         Log("%s\n", ex.what());
+        
+        DebugBreak();
+    
+        // reset all pins to low
+        for (int i = 0; i < NUM_ARDUINO_PINS; i++)
+        {
+            try
+            {
+                g_pins.setPinState(i, LOW);
+            }
+            catch (...)
+            {
+                // silently catch any exceptions raised when trying to set the pins to LOW
+            }
+        }
     }
     catch (const _arduino_quit_exception &)
     {


### PR DESCRIPTION
The DebugBreak is to allow a developer to check the call stack for the problem code.
The DebugBreak was placed in the catch for the _arduino_fatal_error instead of ThrowError since ThrowError is just a wrapper for throw _arduino_fatal_error
