### PR TITLE
Implemented the temperature sensor on the ADC chip for analogRead(-1) on gen1

### DIFF
--- a/source/AD7298Support.h
+++ b/source/AD7298Support.h
@@ -8,6 +8,7 @@
 #include <Windows.h>
 #include "SpiController.h"
 #include "GpioController.h"
+#include "WindowsTime.h"
 
 class AD7298Device
 {
@@ -53,6 +54,12 @@ public:
         m_spi.end();
     }
 
+    /// Take a reading of the ADC temperature sensor on the board.
+    /**
+    \param[out] value The value read from the ADC.
+    \param[out] bits The size of the reading in "value" in bits.
+    \return TRUE, success. FALSE, failure, GetLastError() returns the error code.
+    */
     inline BOOL readTemp(ULONG & value, ULONG & bits)
     {
         BOOL status = TRUE;
@@ -113,7 +120,9 @@ public:
 
         // TsenseBusy should be high until the conversion is completed (100 micro seconds max)
         // wait 100ns after TsenseBusy is low to start reading
-        Sleep(1);
+        LARGE_INTEGER us64;
+        us64.QuadPart = 101;
+        _WindowsTime.delayMicroseconds(us64);
 
         //
         // Get the conversion result from the ADC.

--- a/source/Adc.h
+++ b/source/Adc.h
@@ -75,6 +75,12 @@ public:
         return status;
     }
 
+    /// Take a reading of the ADC temperature sensor on the board.
+    /**
+    \param[out] value The value read from the ADC.
+    \param[out] bits The size of the reading in "value" in bits.
+    \return TRUE, success. FALSE, failure, GetLastError() returns the error code.
+    */
     inline BOOL readTemp(ULONG & value, ULONG & bits)
     {
         BOOL status = TRUE;
@@ -88,7 +94,8 @@ public:
         {
             if (m_boardGeneration == 2)
             {
-                return FALSE;
+                error = ERROR_INVALID_FUNCTION;
+                status = FALSE;
             }
             else
             {

--- a/source/Adc.h
+++ b/source/Adc.h
@@ -75,6 +75,31 @@ public:
         return status;
     }
 
+    inline BOOL readTemp(ULONG & value, ULONG & bits)
+    {
+        BOOL status = TRUE;
+        ULONG error = ERROR_SUCCESS;
+
+        // Verify we have initialized the correct ADC.
+        status = _verifyAdcInitialized();
+        if (!status) { error = GetLastError(); }
+
+        if (status)
+        {
+            if (m_boardGeneration == 2)
+            {
+                return FALSE;
+            }
+            else
+            {
+                return m_gen1Adc.readTemp(value, bits);
+            }
+        }
+
+        if (!status) { SetLastError(error); }
+        return status;
+    }
+
 private:
 
     /// The board generation for which this object has been initialized.

--- a/source/arduino.h
+++ b/source/arduino.h
@@ -281,28 +281,38 @@ inline int analogRead(int pin)
     ULONG bits;
     ULONG ioPin;
 
-    // Translate the pin number passed in to a Galileo GPIO Pin number.
-    if ((pin >= 0) && (pin < NUM_ANALOG_PINS))
+    if (-1 == pin)
     {
-        ioPin = A0 + pin;
-    }
-    else if ((pin >= A0) && (pin <= A5))
-    {
-        ioPin = pin;
+        if (!g_adc.readTemp(value, bits))
+        {
+            ThrowError("Error performing analogRead on temperature pin. Galileo Gen2 does not support this functionality. Error: 0x%08x", GetLastError());
+        }
     }
     else
     {
-        ThrowError("Pin: %d is not an analog input pin.", pin);
-    }
+        // Translate the pin number passed in to a Galileo GPIO Pin number.
+        if ((pin >= 0) && (pin < NUM_ANALOG_PINS))
+        {
+            ioPin = A0 + pin;
+        }
+        else if ((pin >= A0) && (pin <= A5))
+        {
+            ioPin = pin;
+        }
+        else
+        {
+            ThrowError("Pin: %d is not an analog input pin.", pin);
+        }
 
-    if (!g_pins.verifyPinFunction(ioPin, FUNC_AIN, GalileoPinsClass::NO_LOCK_CHANGE))
-    {
-        ThrowError("Error occurred verifying pin: %d function: ANALOG_IN, Error: 0x%08x", ioPin, GetLastError());
-    }
+        if (!g_pins.verifyPinFunction(ioPin, FUNC_AIN, GalileoPinsClass::NO_LOCK_CHANGE))
+        {
+            ThrowError("Error occurred verifying pin: %d function: ANALOG_IN, Error: 0x%08x", ioPin, GetLastError());
+        }
 
-    if (!g_adc.readValue(ioPin, value, bits))
-    {
-        ThrowError("Error performing analogRead on pin: %d, Error: 0x%08x", pin, GetLastError());
+        if (!g_adc.readValue(ioPin, value, bits))
+        {
+            ThrowError("Error performing analogRead on pin: %d, Error: 0x%08x", pin, GetLastError());
+        }
     }
 
     // Scale the digitized analog value to the currently set analog read resolution.

--- a/source/arduino.h
+++ b/source/arduino.h
@@ -267,6 +267,43 @@ inline int digitalRead(int pin)
 /// The number of bits used to return digitized analog values.
 __declspec (selectany) ULONG g_analogValueBits = 10;
 
+/// Perform an analog to digital conversion on the ADC temperature sensor.
+/**
+\return Digitized analog value read from the pin.
+\note The number of bits of the digitized analog value can be set by calling the 
+analogReadResolution() API.  By default ten bits are returned (0-1023 for 0-5v pin voltage).
+\sa analogReadResolution
+*/
+inline int readTemp()
+{
+    ULONG value;
+    ULONG bits;
+    
+    if (!g_adc.readTemp(value, bits))
+    {
+        if (GetLastError() == ERROR_INVALID_FUNCTION)
+        {
+            ThrowError("ReadTemp is not supported on Galileo Gen2. Error: 0x%08x", GetLastError());
+        }
+        else
+        {
+            ThrowError("Error performing analogRead on temperature pin. Error: 0x%08x", GetLastError());
+        }
+    }
+    
+    // Scale the digitized analog value to the currently set analog read resolution.
+    if (g_analogValueBits > bits)
+    {
+        value = value << (g_analogValueBits - bits);
+    }
+    else if (bits > g_analogValueBits)
+    {
+        value = value >> (bits - g_analogValueBits);
+    }
+
+    return value;
+}
+
 /// Perform an analog to digital conversion on one of the analog inputs.
 /**
 \param[in] pin The analog pin to read (A0-A5, or 0-5).
@@ -281,38 +318,28 @@ inline int analogRead(int pin)
     ULONG bits;
     ULONG ioPin;
 
-    if (-1 == pin)
+    // Translate the pin number passed in to a Galileo GPIO Pin number.
+    if ((pin >= 0) && (pin < NUM_ANALOG_PINS))
     {
-        if (!g_adc.readTemp(value, bits))
-        {
-            ThrowError("Error performing analogRead on temperature pin. Galileo Gen2 does not support this functionality. Error: 0x%08x", GetLastError());
-        }
+        ioPin = A0 + pin;
+    }
+    else if ((pin >= A0) && (pin <= A5))
+    {
+        ioPin = pin;
     }
     else
     {
-        // Translate the pin number passed in to a Galileo GPIO Pin number.
-        if ((pin >= 0) && (pin < NUM_ANALOG_PINS))
-        {
-            ioPin = A0 + pin;
-        }
-        else if ((pin >= A0) && (pin <= A5))
-        {
-            ioPin = pin;
-        }
-        else
-        {
-            ThrowError("Pin: %d is not an analog input pin.", pin);
-        }
+        ThrowError("Pin: %d is not an analog input pin.", pin);
+    }
 
-        if (!g_pins.verifyPinFunction(ioPin, FUNC_AIN, GalileoPinsClass::NO_LOCK_CHANGE))
-        {
-            ThrowError("Error occurred verifying pin: %d function: ANALOG_IN, Error: 0x%08x", ioPin, GetLastError());
-        }
+    if (!g_pins.verifyPinFunction(ioPin, FUNC_AIN, GalileoPinsClass::NO_LOCK_CHANGE))
+    {
+        ThrowError("Error occurred verifying pin: %d function: ANALOG_IN, Error: 0x%08x", ioPin, GetLastError());
+    }
 
-        if (!g_adc.readValue(ioPin, value, bits))
-        {
-            ThrowError("Error performing analogRead on pin: %d, Error: 0x%08x", pin, GetLastError());
-        }
+    if (!g_adc.readValue(ioPin, value, bits))
+    {
+        ThrowError("Error performing analogRead on pin: %d, Error: 0x%08x", pin, GetLastError());
     }
 
     // Scale the digitized analog value to the currently set analog read resolution.


### PR DESCRIPTION
The readTemp could be combined with the readValue using a couple if, else statements.
One for the channel being 8 for Tsense
One for the sleep in order to provide enough time to elapse for the conversion.

I chose to make them separate initially for debugging purposes, but then chose to leave it for clarity. This can easily be combined.

Unfortunately the gen2 ADC chip does not seem to provide a temperature sensor that is accessible to us.