### PR TITLE
Cleanup things found during Ika Lure GPIO and PWM testing.

### DIFF
--- a/source/GpioController.h
+++ b/source/GpioController.h
@@ -1305,6 +1305,7 @@ inline void BtFabricGpioControllerClass::_setS0PinInput(ULONG gpioNo)
     _PCONF0 padConfig;
     padConfig.ALL_BITS = m_s0Controller[gpioNo].PCONF0.ALL_BITS;
     padConfig.BYPASS_FLOP = 1;			// Disable flop
+    padConfig.PULL_ASSIGN = 0;          // Disable pull-up
     m_s0Controller[gpioNo].PCONF0.ALL_BITS = padConfig.ALL_BITS;
 
     _PAD_VAL padVal;
@@ -1324,6 +1325,7 @@ inline void BtFabricGpioControllerClass::_setS5PinInput(ULONG gpioNo)
     _PCONF0 padConfig;
     padConfig.ALL_BITS = m_s5Controller[gpioNo].PCONF0.ALL_BITS;
     padConfig.BYPASS_FLOP = 1;			// Disable flop
+    padConfig.PULL_ASSIGN = 0;			// No pull resistor
     m_s5Controller[gpioNo].PCONF0.ALL_BITS = padConfig.ALL_BITS;
 
     _PAD_VAL padVal;

--- a/source/arduino.h
+++ b/source/arduino.h
@@ -495,7 +495,6 @@ void serialEvent1();
 inline int RunArduinoSketch()
 {
     int ret = 0;
-    BoardPinsClass::BOARD_TYPE board;
 
     try
     {


### PR DESCRIPTION
Remove SOC pad pull-ups when configured as GPIO inputs.
Remove unneeded variable in arduino.h.